### PR TITLE
Add xenial build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ before_install:
     sudo dpkg -i ../*.deb
     pg_buildext -i '--locale=C.UTF-8' -o local_preload_libraries=pgextwlist -o extwlist.extensions=citext,earthdistance,pg_trgm installcheck
 
-    exit 0
   - chmod 755 ../deb-build/build.sh
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,74 @@
-language: C
 sudo: required
 dist: trusty
+services:
+  - docker
 env:
-  - PG_SUPPORTED_VERSIONS=9.2
-  - PG_SUPPORTED_VERSIONS=9.3
-  - PG_SUPPORTED_VERSIONS=9.4
-  - PG_SUPPORTED_VERSIONS=9.5
-  - PG_SUPPORTED_VERSIONS=9.6
-  - PG_SUPPORTED_VERSIONS=10
-  - PG_SUPPORTED_VERSIONS=11
+  - PG_SUPPORTED_VERSIONS=9.3 DIST=trusty
+  - PG_SUPPORTED_VERSIONS=9.4 DIST=trusty
+  - PG_SUPPORTED_VERSIONS=9.5 DIST=trusty
+  - PG_SUPPORTED_VERSIONS=9.6 DIST=trusty
+  - PG_SUPPORTED_VERSIONS=10  DIST=trusty
+  - PG_SUPPORTED_VERSIONS=9.3 DIST=xenial
+  - PG_SUPPORTED_VERSIONS=9.4 DIST=xenial
+  - PG_SUPPORTED_VERSIONS=9.5 DIST=xenial
+  - PG_SUPPORTED_VERSIONS=9.6 DIST=xenial
+  - PG_SUPPORTED_VERSIONS=10  DIST=xenial
 before_install:
-  # apt.postgresql.org is already configured, we just need to add devel
+  - docker pull heroku/dod-package-dev:$DIST
+  - mkdir -p ../deb-build ../packages/$DIST
   - |
-    DIST=trusty-pgdg
+    cat <<'EOF' > ../deb-build/build.sh
+    #!/bin/sh -x
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     case $PG_SUPPORTED_VERSIONS in
       11)
       # update pgdg-source.list
-      sudo sed -i -e "s/pgdg.*/pgdg-testing main $PG_SUPPORTED_VERSIONS/" /etc/apt/sources.list.d/pgdg*.list
-      DIST=trusty-pgdg-testing
+      sed -i -e "s/pgdg.*/pgdg-testing main $PG_SUPPORTED_VERSIONS/" /etc/apt/sources.list.d/pgdg*.list
+      export DIST=$DIST-pgdg-testing
+      ;;
+      *)
+      export DIST=$DIST-pgdg
       ;;
     esac
-  - sudo apt-get -q update
-install:
-  - export DEBIAN_FRONTEND=noninteractive # suppress warnings about deprecated PostgreSQL versions
-  # trusty's pg-srv-dev-all is too old, use -t $DIST to force installation of the pgdg version
-  - sudo apt-get install -t $DIST debhelper fakeroot postgresql-common postgresql-server-dev-all postgresql-server-dev-$PG_SUPPORTED_VERSIONS
-  # install PostgreSQL $PG_SUPPORTED_VERSIONS if not there yet
-  - |
+
+    apt-get update -y
+    apt-get install -y -t $DIST debhelper fakeroot postgresql-common postgresql-server-dev-all postgresql-server-dev-$PG_SUPPORTED_VERSIONS
+
     if [ ! -x /usr/lib/postgresql/$PG_SUPPORTED_VERSIONS/bin/postgres ]; then
       sudo /etc/init.d/postgresql stop # stop postgresql again before installing the server
-      sudo apt-get install postgresql-$PG_SUPPORTED_VERSIONS
+      apt-get install -y postgresql-$PG_SUPPORTED_VERSIONS
     fi
-  # stop the travis-provided cluster
-  - sudo /etc/init.d/postgresql stop
-  - pg_lsclusters
-  - dpkg -l postgresql\* | cat
+
+    /etc/init.d/postgresql stop
+    pg_lsclusters
+    dpkg -l postgresql\* | cat
+
+    cd /root/build/pgextwlist
+
+    pg_buildext updatecontrol
+    dpkg-buildpackage -us -uc -rfakeroot
+    for deb in ../*.deb; do echo "$deb:"; dpkg-deb --info $deb; dpkg-deb --contents $deb; done
+    sudo dpkg -i ../*.deb
+    pg_buildext -i '--locale=C.UTF-8' -o local_preload_libraries=pgextwlist -o extwlist.extensions=citext,earthdistance,pg_trgm installcheck
+
+    exit 0
+  - chmod 755 ../deb-build/build.sh
 script:
-  - pg_buildext updatecontrol
-  - dpkg-buildpackage -us -uc -rfakeroot
-  - for deb in ../*.deb; do echo "$deb:"; dpkg-deb --info $deb; dpkg-deb --contents $deb; done
-  - sudo dpkg -i ../*.deb
-  - pg_buildext -i '--locale=C.UTF-8' -o local_preload_libraries=pgextwlist -o extwlist.extensions=citext,earthdistance,pg_trgm installcheck
-  - DIST=trusty
+  - |
+    docker run -v $(readlink -f ../deb-build):/root/deb-build \
+               -v $(readlink -f ../packages/$DIST):/root/build \
+               -v $(readlink -f .):/root/build/pgextwlist \
+               -e DIST=$DIST -e PG_SUPPORTED_VERSIONS=$PG_SUPPORTED_VERSIONS \
+               --privileged=true -it heroku/dod-package-dev:$DIST \
+               bash -x /root/deb-build/build.sh
+  - du -a ../packages/$DIST
 deploy:
   - provider: packagecloud
     dist: ubuntu/$DIST
-    package_glob: ../*.deb
+    package_glob: ../packages/$DIST/*.deb
     username: heroku
     repository: dod
     token:


### PR DESCRIPTION
Use docker to build the packages, so we can build xenial and trusty packages.