### PR TITLE
Build for bionic & focal, retire trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,31 @@
 sudo: required
-dist: trusty
-language: C
+os: linux
+dist: focal
+language: c
 services:
   - docker
 env:
-  - PG_SUPPORTED_VERSIONS=9.3 DIST=trusty
-  - PG_SUPPORTED_VERSIONS=9.4 DIST=trusty
-  - PG_SUPPORTED_VERSIONS=9.5 DIST=trusty
-  - PG_SUPPORTED_VERSIONS=9.6 DIST=trusty
-  - PG_SUPPORTED_VERSIONS=10  DIST=trusty
-  - PG_SUPPORTED_VERSIONS=11  DIST=trusty
   - PG_SUPPORTED_VERSIONS=9.3 DIST=xenial
   - PG_SUPPORTED_VERSIONS=9.4 DIST=xenial
   - PG_SUPPORTED_VERSIONS=9.5 DIST=xenial
   - PG_SUPPORTED_VERSIONS=9.6 DIST=xenial
   - PG_SUPPORTED_VERSIONS=10  DIST=xenial
   - PG_SUPPORTED_VERSIONS=11  DIST=xenial
-  - PG_SUPPORTED_VERSIONS=12 COMPONENT=12 DIST=xenial
+  - PG_SUPPORTED_VERSIONS=12  DIST=xenial
+  - PG_SUPPORTED_VERSIONS=9.3 DIST=bionic
+  - PG_SUPPORTED_VERSIONS=9.4 DIST=bionic
+  - PG_SUPPORTED_VERSIONS=9.5 DIST=bionic
+  - PG_SUPPORTED_VERSIONS=9.6 DIST=bionic
+  - PG_SUPPORTED_VERSIONS=10  DIST=bionic
+  - PG_SUPPORTED_VERSIONS=11  DIST=bionic
+  - PG_SUPPORTED_VERSIONS=12  DIST=bionic
+  - PG_SUPPORTED_VERSIONS=9.3 DIST=focal
+  - PG_SUPPORTED_VERSIONS=9.4 DIST=focal
+  - PG_SUPPORTED_VERSIONS=9.5 DIST=focal
+  - PG_SUPPORTED_VERSIONS=9.6 DIST=focal
+  - PG_SUPPORTED_VERSIONS=10  DIST=focal
+  - PG_SUPPORTED_VERSIONS=11  DIST=focal
+  - PG_SUPPORTED_VERSIONS=12  DIST=focal
 before_install:
   - docker pull heroku/dod-package-dev:$DIST
   - mkdir -p ../deb-build ../packages/$DIST
@@ -25,18 +34,8 @@ before_install:
     #!/bin/sh -x
     export DEBIAN_FRONTEND=noninteractive
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-    case $PG_SUPPORTED_VERSIONS in
-      11)
-      # update pgdg-source.list
-      sed -i -e "s/pgdg.*/pgdg-testing main $PG_SUPPORTED_VERSIONS/" /etc/apt/sources.list.d/pgdg*.list
-      export DIST=$DIST-pgdg-testing
-      ;;
-      *)
-      export DIST=$DIST-pgdg
-      ;;
-    esac
     apt-get update -y
-    apt-get install -y -t $DIST debhelper fakeroot postgresql-common postgresql-server-dev-all postgresql-server-dev-$PG_SUPPORTED_VERSIONS
+    apt-get install -y -t $DIST-pgdg libpq5 libpq-dev clang debhelper fakeroot postgresql-common postgresql-server-dev-all postgresql-server-dev-$PG_SUPPORTED_VERSIONS postgresql-client-$PG_SUPPORTED_VERSIONS
     if [ ! -x /usr/lib/postgresql/$PG_SUPPORTED_VERSIONS/bin/postgres ]; then
       sudo /etc/init.d/postgresql stop # stop postgresql again before installing the server
       apt-get install -y postgresql-$PG_SUPPORTED_VERSIONS

--- a/debian/control
+++ b/debian/control
@@ -75,13 +75,13 @@ Description: PostgreSQL Extension Whitelisting
  extensions will get installed as if superuser. Privileges are dropped before
  handing the control back to the user.
 
- Package: postgresql-12-pgextwlist
- Section: libs
- Architecture: any
- Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-12
- Description: PostgreSQL Extension Whitelisting
-  This extension implements extension whitelisting, and will actively prevent
-  users from installing extensions not in the provided list. Also, this
-  extension implements a form of sudo facility in that the whitelisted
-  extensions will get installed as if superuser. Privileges are dropped before
-  handing the control back to the user.
+Package: postgresql-12-pgextwlist
+Section: libs
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-12
+Description: PostgreSQL Extension Whitelisting
+ This extension implements extension whitelisting, and will actively prevent
+ users from installing extensions not in the provided list. Also, this
+ extension implements a form of sudo facility in that the whitelisted
+ extensions will get installed as if superuser. Privileges are dropped before
+ handing the control back to the user.


### PR DESCRIPTION
As part of the Bionic/Focal work, we need to build `pgextwlist` for the
target distributions. As part of this, I've also retired `trusty` as a
build target.

This cleans up the `.travis.yml`, and also cleans up some formatting
errors in the `debian/control` file.

Ref: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008DR23IAG/view